### PR TITLE
GET /delegated/identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ services:
       HOST_PORT: 8085
       # DLT CONFIG
       NODE_URL: https://stardust.unican.sedimark.eu
-      FAUCET_API_ENDPOINT: https://faucet.tangle.stardust.linksfoundation.com/api/enqueue
+      FAUCET_API_ENDPOINT: https://stardust.linksfoundation.com/faucet/l1/api/enqueue
       RPC_PROVIDER: https://stardust.unican.sedimark.eu/sedimark-chain
       CHAIN_ID: 1074
       # ISSUER CONFIG

--- a/api/dlt-booth-api/Delegated/Get Identity.bru
+++ b/api/dlt-booth-api/Delegated/Get Identity.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Get Identity
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{BASE_URL}}/delegated/identities
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "credential": {
+      "alternateName": "someUsername"
+    },
+    "services":[
+      {
+        "id": "service-link",
+        "type": "ServiceType",
+        "serviceEndpoint":"http://example.com"
+      }
+    ]
+  }
+}

--- a/api/dlt_booth.yaml
+++ b/api/dlt_booth.yaml
@@ -72,12 +72,37 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+    get:
+      tags:
+        - Delegated
+      summary: Get identity
+      responses:
+        200:
+          description: Get credential
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CredentialJwt'  
+        404:
+          description:  Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Operation aborted due to an unexpected error during execution
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      description: If the booth is registered, it returns the JWT payload enveloping a Verifiable Credential
   /dids/{did}:
     parameters:
       - in: path
         name: did
         required: true
-        type: string
+        schema:
+          type: string
     get:
       summary: Resolve a DID on the configured public utility
       description: Given a DID as an input, it queries the configured node as a client to retrieve the current state of the DID Document
@@ -106,38 +131,23 @@ components:
   schemas:
     CredentialJwt:
       type: object
-      properties:
-        credential:
-          description: The verifiable credential of the user in JWT format (Upon identity creation, its value is undefined, the credential must be requested to an Issuer).
-          type: string
-          example: "eyJraWQiOiJkaWQ6aW90YTpybXM6MHhhMTM2Yjk1YTFmMzc0ZWQwN2M1NDkzOTQ0ZmMwYWYyZjM5NmU3YzExNTAzNDhhZmJhZGVlYmI5ZmVkNjExYzMxI3BjT0lUbnUxSTBqSm9HM3JJNnFaZGtrVTVLaDUwNnctYnExc2t5QjBXOTAiLCJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSJ9.eyJleHAiOjE3NDI4OTMyNDUsImlzcyI6ImRpZDppb3RhOnJtczoweGExMzZiOTVhMWYzNzRlZDA3YzU0OTM5NDRmYzBhZjJmMzk2ZTdjMTE1MDM0OGFmYmFkZWViYjlmZWQ2MTFjMzEiLCJuYmYiOjE3MTEyNzA4NDUsImp0aSI6Imh0dHBzOi8vZXhhbXBsZS5tYXJrZXQvY3JlZGVudGlhbHMvMSIsInN1YiI6ImRpZDppb3RhOnJtczoweGIwYTVjNTM5NTNhMjhhZDJmMzg4MGIwOTg3ODI2NWU5OGRiMGJkM2Y5NmQxNjZiMjMzZWM4NGNkYWRiYjI0MmIiLCJ2YyI6eyJAY29udGV4dCI6Imh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL3YxIiwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIk1hcmtldHBsYWNlQ3JlZGVudGlhbCJdLCJjcmVkZW50aWFsU3ViamVjdCI6eyJuYW1lIjoiSm9obiIsInN1cm5hbWUiOiJEb2UgRG9lIiwidXNlck9mIjoiU0VESU1BUksgbWFya2V0cGxhY2UifX19.-6dTIWJUwmaOQq6IJz4hh3SEwBz2lKnUmY19av4nZY3wcTi7hp0TY2rn3G8vsMYIft4VFZCwSlAHi28GwpiBAQ"
-    DidDocument:
-      type: object
-      example: '{
-  "doc": {
-    "id": "did:iota:lnk:0x94e4a3c83a66c2592069e74937887f9f2baf63d96f156d36dabd3f3482395324",
-    "verificationMethod": [
-      {
-        "id": "did:iota:lnk:0x94e4a3c83a66c2592069e74937887f9f2baf63d96f156d36dabd3f3482395324#m0K_TnUAenJRKuJ_WU8prsHavPcsACNdRRxk3vPl8Mg",
-        "controller": "did:iota:lnk:0x94e4a3c83a66c2592069e74937887f9f2baf63d96f156d36dabd3f3482395324",
-        "type": "JsonWebKey2020",
-        "publicKeyJwk": {
-          "kty": "OKP",
-          "alg": "EdDSA",
-          "kid": "m0K_TnUAenJRKuJ_WU8prsHavPcsACNdRRxk3vPl8Mg",
-          "crv": "Ed25519",
-          "x": "Fl_ytZJjvo6mDXhydn-ah-RLcyWXX1mVJRKKGlJ21Ds"
-        }
-      }
-    ]
-  },
-  "meta": {
-    "created": "2025-02-17T10:37:29Z",
-    "updated": "2025-02-17T10:37:29Z",
-    "governorAddress": "lnk1qqg0e766887n74jj70mgagmgkvvdzwk9f6mz9m67gje249e683wlslhqw98",
-    "stateControllerAddress": "lnk1qqg0e766887n74jj70mgagmgkvvdzwk9f6mz9m67gje249e683wlslhqw98"
-  }
-}'
+      example: 
+       exp: 1775049930
+       iss: did:iota:lnk:0x9f42fd4d8712613760030e0ae3bc53decc39b4c889b1ea8db2b1aa007d734893
+       nbf: 1743427530
+       jti: http://sedimark-issuer:3213/api/credentials/6
+       sub: did:iota:lnk:0x73ec91fcd41f30836169f2a7b89166b6ba0093209a03d236e96e79c5e63cb230
+       vc:
+         '@context':
+           - https://www.w3.org/2018/credentials/v1
+           - schema: http://schema.org/
+         type:
+           - VerifiableCredential
+           - MarketplaceCredential
+         credentialSubject:
+           schema:alternateName: someUsername
+           schema:memberOf: SEDIMARK marketplace
+                   
     Credential:
       type: object
       properties:
@@ -165,6 +175,28 @@ components:
             $ref: '#/components/schemas/Service'
       required:
         - credential
+    DidDocument:
+      type: object
+      example:
+        doc:
+          id: did:iota:lnk:0x94e4a3c83a66c2592069e74937887f9f2baf63d96f156d36dabd3f3482395324
+          verificationMethod:
+            - id: did:iota:lnk:0x94e4a3c83a66c2592069e74937887f9f2baf63d96f156d36dabd3f3482395324#m0K_TnUAenJRKuJ_WU8prsHavPcsACNdRRxk3vPl8Mg
+              controller: did:iota:lnk:0x94e4a3c83a66c2592069e74937887f9f2baf63d96f156d36dabd3f3482395324
+              type: JsonWebKey2020
+              publicKeyJwk:
+                kty: OKP
+                alg: EdDSA
+                kid: m0K_TnUAenJRKuJ_WU8prsHavPcsACNdRRxk3vPl8Mg
+                crv: Ed25519
+                x: Fl_ytZJjvo6mDXhydn-ah-RLcyWXX1mVJRKKGlJ21Ds
+          meta:
+            created: '2025-02-17T10:37:29Z'
+            updated: '2025-02-17T10:37:29Z'
+            governorAddress: lnk1qqg0e766887n74jj70mgagmgkvvdzwk9f6mz9m67gje249e683wlslhqw98
+            stateControllerAddress: lnk1qqg0e766887n74jj70mgagmgkvvdzwk9f6mz9m67gje249e683wlslhqw98
+              
+      
     Error:
       type: object
       required:

--- a/dlt-booth/src/controllers/delegated_identities.rs
+++ b/dlt-booth/src/controllers/delegated_identities.rs
@@ -62,8 +62,9 @@ async fn create_identity(
     let updated_identity = pg_client.set_credential(&created_identity.eth_address, &created_identity.vcredential).await?;
     log::info!("Vc saved!");
     
-    match updated_identity.vcredential {
-        Some(vc) => Ok(HttpResponse::Ok().json(json!({"credential": vc}))),
+    match updated_identity.vcredential
+    .and_then(|jwt| decode_vc_unverified(&jwt)) {
+        Some(decoded) => Ok(HttpResponse::Ok().json(decoded)),
         None => Ok(HttpResponse::InternalServerError().json(json!({"message": "Unexpected error when reading VC"})))
     }
 

--- a/dlt-booth/src/controllers/delegated_identities.rs
+++ b/dlt-booth/src/controllers/delegated_identities.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use actix_web::{delete, post};
+use actix_web::{delete, get, post};
 use actix_web::{web, HttpResponse};
 use deadpool_postgres::Pool;
 use identity_iota::iota::IotaDID;
@@ -12,6 +12,7 @@ use crate::models::identity::Identity;
 use crate::repository::identity_operations::IdentityExt;
 use crate::utils::iota::IotaState;
 use crate::utils::issuer::Issuer;
+use crate::utils::jwt::decode_vc_unverified;
 
 
 #[post("/identities")] 
@@ -68,6 +69,29 @@ async fn create_identity(
 
 }
 
+#[get("/identities")]
+async fn get_identity(
+    db_pool: web::Data<Pool>,
+    iota_state: web::Data<IotaState>,
+)-> Result<HttpResponse, ConnectorError> {
+    log::debug!("controller get_identity");
+    let pg_client = db_pool.get().await.map_err(ConnectorError::PoolError)?;
+    let eth_address = iota_state.get_evm_address().await?;
+
+    match pg_client.get_identity_with_eth_addr(&eth_address).await
+    .and_then(|res| res.vcredential
+    .ok_or(ConnectorError::RowNotFound)) {
+        Ok(jwt) => {
+            // decode Verifiable credential
+            decode_vc_unverified(&jwt)
+            .ok_or(ConnectorError::OtherError("Bad VC Format".to_owned()))
+            .map(|vc| HttpResponse::Ok().json(vc))
+        },
+        Err(ConnectorError::RowNotFound) => Ok(HttpResponse::NotFound().json(json!({"message": "No VC found"}))),
+        Err(e) => Err(e)
+    }
+}
+
 #[delete("/identities")]
 async fn delete_identity(
     db_pool: web::Data<Pool>,
@@ -94,8 +118,8 @@ pub fn scoped_config(cfg: &mut web::ServiceConfig) {
     .service(web::scope("/delegated")
         .service(create_identity)
         .service(delete_identity)
+        .service(get_identity)
     );
-    //.service(get_identity)     
     //.service(patch_identity)       
     //.service(sign_data)
     //.service(gen_presentation);

--- a/dlt-booth/src/utils/issuer.rs
+++ b/dlt-booth/src/utils/issuer.rs
@@ -5,7 +5,7 @@
 use std::str::FromStr;
 use alloy::hex::ToHexExt;
 use identity_eddsa_verifier::EdDSAJwsVerifier;
-use identity_iota::{core::Object, credential::{JwtCredentialValidationOptions, JwtCredentialValidator}, document::verifiable::JwsVerificationOptions, iota::IotaDocument};
+use identity_iota::{core::Object, credential::JwtCredentialValidator, document::verifiable::JwsVerificationOptions, iota::IotaDocument};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use url::Url;

--- a/dlt-booth/src/utils/jwt.rs
+++ b/dlt-booth/src/utils/jwt.rs
@@ -1,0 +1,14 @@
+use identity_iota::verification::jwu::decode_b64_json;
+use serde_json::Value;
+
+/// Decode a verifiable credential JWT without the Issuer DID document. 
+/// 
+/// Use it only if the credential has been already verified.
+pub fn decode_vc_unverified(jwt: &str) -> Option<Value>{
+
+    jwt
+        .split('.')
+        .skip(1)
+        .next()
+        .and_then(|str| decode_b64_json::<Value>(str).ok())
+}

--- a/dlt-booth/src/utils/mod.rs
+++ b/dlt-booth/src/utils/mod.rs
@@ -7,3 +7,4 @@ pub mod configs;
 pub mod issuer;
 pub mod alloy_signer;
 pub mod stronghold_local_wallet;
+pub mod jwt;


### PR DESCRIPTION
Hi @xamcost,
I'm opening this as a draft since testing is very slow due to compilation time.
The GET /delegated/identity is completed. It basically contains the decocded JWT payload of the Verifiable Credential. You can test it on the Bruno collection available in the repo.
I'll extend the same format to the endpoint for identity creation.

Please let me know if you need anything else. If everything is fine I'll update the openapi spec and merge