### PR TITLE
maint: add missing env variables for smart contracts

### DIFF
--- a/kubernetes/010-dlt-booth-configmap.yaml
+++ b/kubernetes/010-dlt-booth-configmap.yaml
@@ -27,5 +27,9 @@ data:
   DB_HOST: ${DLT_BOOTH_APP_NAME}-postgres.${DLT_BOOTH_NAMESPACE}.svc.cluster.local # "postgres" for deploying, "127.0.0.1 " for dev
   DB_PORT: "5432"
   DB_MAX_POOL_SIZE: "16"
+
+  # Smart Contracts
+  FACTORY_SC_ADDRESS: ${DLT_BOOTH_FACTORY_SC_ADDRESS}
+  FIXED_RATE_EXCHANGE_SC_ADDRESS: ${DLT_BOOTH_FIXED_RATE_EXCHANGE_SC_ADDRESS}
 ---
 


### PR DESCRIPTION
Hi there! This ultra tiny PR adds the missing variables in the configmap of the kubernetes manifests, following the recent updates of the dlt booth.